### PR TITLE
correct editURL for base and language support

### DIFF
--- a/src/hugo/config.toml
+++ b/src/hugo/config.toml
@@ -10,7 +10,7 @@ uglyurls = false
 
 [params]
 ordersectionsby = "weight"
-editURL = "https://github.com/aws/iot-atlas/tree/main/content/"
+editURL = "https://github.com/aws/iot-atlas/tree/main/src/hugo/content/"
 themeVariant = "aws"
 disableLandingPageButton = false
 disableNextPrev = true
@@ -32,7 +32,7 @@ languageName = "English"
 weight = 1
 
   [languages.en.params]
-  editURL = "https://github.com/aws/iot-atlas/tree/main/content/en-us/"
+  editURL = "https://github.com/aws/iot-atlas/tree/main/src/hugo/content/en-us/"
 
 [languages.zh]
 lang = "zh"
@@ -42,7 +42,7 @@ languageName = "中文(简体)"
 weight = 2
 
   [languages.zh.params]
-  editURL = "https://github.com/aws/iot-atlas/tree/main/content/zh-cn/"
+  editURL = "https://github.com/aws/iot-atlas/tree/main/src/hugo/content/zh-cn/"
 
 [languages.fr]
 lang = "fr"
@@ -52,4 +52,4 @@ languageName = "French"
 weight = 3
 
   [languages.fr.params]
-  editURL = "https://github.com/aws/iot-atlas/tree/main/content/fr-fr/"
+  editURL = "https://github.com/aws/iot-atlas/tree/main/src/hugo/content/fr-fr/"

--- a/src/make_hugo.sh
+++ b/src/make_hugo.sh
@@ -62,6 +62,7 @@ function hugo_validate {
 function uri_path_validate {
     # Run link checker for specific URI
     # Note - run the container on the host network to access Hugo running in a separate container
+    #      - Exclude on github.com/aws in case of editURL changes. Will catch during automation   
     echo "********** Running link checks on language: $1"
     if ! docker run --net="host" raviqqe/muffet \
             "--exclude=https://github.com/aws/" \


### PR DESCRIPTION
Description of changes:
- Corrected Hugo editURL to point to the new content location of `src/hugo/content/` instead of `content/` from top of repository.
- comment on why link checker doesn't run on structural links such as the editURL one above.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
