### PR TITLE
aliases for previous announce links

### DIFF
--- a/src/hugo/content/en-us/patterns/command/_index.md
+++ b/src/hugo/content/en-us/patterns/command/_index.md
@@ -1,6 +1,8 @@
 ---
 title: "Command"
 weight: 11
+aliases:
+  - /designs/command/
 ---
 
 A requesting entity reliably asks a device to perform a single action, with acknowledgement of status.

--- a/src/hugo/content/en-us/patterns/device_bootstrap/_index.md
+++ b/src/hugo/content/en-us/patterns/device_bootstrap/_index.md
@@ -1,6 +1,8 @@
 ---
 title: "Device Bootstrap"
 weight: 15
+aliases:
+  - /designs/device_bootstrap/
 ---
 
 An unregistered device becomes registered and fully functional in an IoT solution.

--- a/src/hugo/content/en-us/patterns/device_state_replica/_index.md
+++ b/src/hugo/content/en-us/patterns/device_state_replica/_index.md
@@ -1,6 +1,8 @@
 ---
 title: "Device State Replica"
 weight: 20
+aliases:
+  - /designs/device_state_replica/
 ---
 
 {{< synopsis-state-replica >}}

--- a/src/hugo/content/en-us/patterns/gateway/_index.md
+++ b/src/hugo/content/en-us/patterns/gateway/_index.md
@@ -1,6 +1,8 @@
 ---
 title: "Gateway"
 weight: 50
+aliases:
+  - /designs/gateway/
 ---
 
 {{< synopsis-gateway >}}

--- a/src/hugo/content/en-us/patterns/software_update/_index.md
+++ b/src/hugo/content/en-us/patterns/software_update/_index.md
@@ -1,6 +1,8 @@
 ---
 title: "Software Update"
 weight: 70
+aliases:
+  - /designs/software_update/
 ---
 
 {{< synopsis-software-update >}}

--- a/src/hugo/content/en-us/patterns/telemetry/_index.md
+++ b/src/hugo/content/en-us/patterns/telemetry/_index.md
@@ -1,6 +1,8 @@
 ---
 title: "Telemetry"
 weight: 80
+aliases:
+  - /designs/telemetry/
 ---
 
 {{< synopsis-telemetry >}}

--- a/src/hugo/content/en-us/patterns/telemetry_archiving/_index.md
+++ b/src/hugo/content/en-us/patterns/telemetry_archiving/_index.md
@@ -1,6 +1,8 @@
 ---
 title: "Telemetry Archiving"
 weight: 85
+aliases:
+  - /designs/telemetry_archiving/
 ---
 
 {{< synopsis-archiving >}}


### PR DESCRIPTION
Description of changes:

- added aliases for the initial pages referenced in inbound articles to correct 403

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
