### PR TITLE
clean up containers, remove extra dir

### DIFF
--- a/build/README.me
+++ b/build/README.me
@@ -1,1 +1,0 @@
-This folder contains the tooling used to build the test and deployment of the IoT Atlas site.

--- a/src/make_hugo.sh
+++ b/src/make_hugo.sh
@@ -69,7 +69,7 @@ function uri_path_validate {
     # Note - run the container on the host network to access Hugo running in a separate container
     #      - Exclude on github.com/aws in case of editURL changes. Will catch during automation   
     echo "********** Running link checks on language: $1"
-    if ! docker run --net="host" raviqqe/muffet \
+    if ! docker run --rm --net="host" raviqqe/muffet \
             "--exclude=https://github.com/aws/" \
             "--buffer-size=8192" \
             http://localhost:1313/$1/; then


### PR DESCRIPTION
Issue #, if available:

Description of changes:

- Added `--rm` to muffet link checker to clean up containers
- removed `build/` directory, replaced through the `src/` build process

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
