### PR TITLE
move go proxy to layer that uses it

### DIFF
--- a/src/Dockerfile-build
+++ b/src/Dockerfile-build
@@ -19,8 +19,7 @@ WORKDIR /tmp
 # Install golang and disable proxy
 RUN curl -JLO https://golang.org/dl/go1.16.3.linux-amd64.tar.gz \
     && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.16.3.linux-amd64.tar.gz \
-    && rm /tmp/go1.16.3.linux-amd64.tar.gz \
-    && go env -w GOPROXY=direct
+    && rm /tmp/go1.16.3.linux-amd64.tar.gz
 
 ### Download Hugo source, compile, install
 # Prepare source file changes
@@ -32,6 +31,7 @@ RUN curl -JLO https://github.com/gohugoio/hugo/archive/refs/tags/v${HUGO_VERSION
     && cp /tmp/convert.go /tmp/hugo-${HUGO_VERSION}/markup/goldmark/convert.go \
     && cp config.go /tmp/hugo-${HUGO_VERSION}/markup/goldmark/goldmark_config/config.go \
     && cd hugo-${HUGO_VERSION} \
+    && go env -w GOPROXY=direct \
     && go get github.com/OhYee/goldmark-plantuml@v1.0.3 \
     && go install --tags extended \
     && mv $HOME/go/bin/hugo /hugo \

--- a/src/hugo/content/en-us/contribute/_index.md
+++ b/src/hugo/content/en-us/contribute/_index.md
@@ -14,7 +14,7 @@ Following these guidelines helps ensure the consistency of the Atlas from page t
 
 When creating new content, use the follow guidance:
 
-1. A customized Hugo [Learn Theme](https://themes.gohugo.io//theme/hugo-theme-learn) is the basis for this site. Unless extended or called out below, all Learn Theme design content and shortcodes can be used. Additional features are listed below and shown in the [templates]({{< ref "/contribute/templates" >}}) folder, or in the [kitchen sink]({{< ref "/contribute/kitchen_sink" >}}) example that demonstrates all features.
+1. A customized Hugo [Learn Theme](https://themes.gohugo.io/themes/hugo-theme-learn/) is the basis for this site. Unless extended or called out below, all Learn Theme design content and shortcodes can be used. Additional features are listed below and shown in the [templates]({{< ref "/contribute/templates" >}}) folder, or in the [kitchen sink]({{< ref "/contribute/kitchen_sink" >}}) example that demonstrates all features.
 1. If creating similar content that already exists, use an existing page as the basis for headings, style, and approach. You can also review the example style templates in this section.
 1. Test content changes locally and only submit a [pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests) once the validation passes successfully. Pull requests will not be merged with broken links or invalid Hugo references/code.
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Go proxy wasn't honored in previous layer. Moved to layer that pulls go modules.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
