### PR TITLE
Fixed topic name for software update example

### DIFF
--- a/src/hugo/content/en-us/patterns/software_update/_index.md
+++ b/src/hugo/content/en-us/patterns/software_update/_index.md
@@ -85,7 +85,7 @@ def message_listener(message):
 
 #### Device applies software and publishes acknowledgement message
 
-A device will apply the downloaded software and acknowledge the command completion with a message to `state/deviceID/update/accepted` topic
+A device will apply the downloaded software and acknowledge the command completion with a message to `state/deviceID/update` topic
 
 ```python
 def apply_software(software, job_id):
@@ -100,7 +100,7 @@ def apply_software(software, job_id):
         message = 'jobID:' + job_id + " FAILURE"
 
     # the topic used to publish the acknowledge message
-    topic = 'state/deviceID/update/accepted'
+    topic = 'state/deviceID/update'
     # ...and finally, publish the acknowledge message
     message_publish(topic, message, quality_of_service)
 ```

--- a/src/hugo/content/fr-fr/designs/software_update/_index.md
+++ b/src/hugo/content/fr-fr/designs/software_update/_index.md
@@ -88,7 +88,7 @@ def message_listener(message):
 
 #### L'appareil effectue une mmise à jour logicielle et publie un message d'accusé de réception
 
-Un appareil effectuera la mise à jour logicielle téléchargée et accusera réception de la commande avec un message sur le sujet `state/deviceID/update/accepted`
+Un appareil effectuera la mise à jour logicielle téléchargée et accusera réception de la commande avec un message sur le sujet `state/deviceID/update`
 
 ```python
 def apply_software(software, job_id):
@@ -103,7 +103,7 @@ def apply_software(software, job_id):
         message = 'jobID:' + job_id + " FAILURE"
 
     # the topic used to publish the acknowledge message
-    topic = 'state/deviceID/update/accepted'
+    topic = 'state/deviceID/update'
     # ...and finally, publish the acknowledge message
     message_publish(topic, message, quality_of_service)
 ```

--- a/src/hugo/content/zh-cn/designs/software_update/_index.md
+++ b/src/hugo/content/zh-cn/designs/software_update/_index.md
@@ -88,7 +88,7 @@ def message_listener(message):
 
 #### 设备应用软件更新并发布确认消息
 
-设备执行更新并将执行更新的结果发布到`state/deviceID/update/accepted`主题上以完成对命令的确认
+设备执行更新并将执行更新的结果发布到`state/deviceID/update`主题上以完成对命令的确认
 
 ```python
 def apply_software(software, job_id):
@@ -103,7 +103,7 @@ def apply_software(software, job_id):
         message = 'jobID:' + job_id + "FAILURE"
 
     # the topic used to publish the acknowledge message
-    topic = 'state/deviceID/update/accepted'
+    topic = 'state/deviceID/update'
     # ...and finally, publish the acknowledge message
     message_publish(topic, message, quality_of_service)
 ```


### PR DESCRIPTION
To be consistent with step 8 of diagram description the device publishes to `state/deviceID/update` topic instead of `state/deviceID/update/accepted`.

Description of changes:

Removed `/accepted` sub topic from all software update examples in all languages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
