### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/comment_pr.yml
+++ b/.github/workflows/comment_pr.yml
@@ -5,6 +5,9 @@ on:
     workflows: ["Receive PR"]
     types:
       - completed
+permissions:
+  pull-requests: write
+
 jobs:
   comment_on_success:
     runs-on: ubuntu-latest

--- a/.github/workflows/receive_pr.yml
+++ b/.github/workflows/receive_pr.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   validate_hugo_content:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.