### PR TITLE
Add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/comment_pr.yml
+++ b/.github/workflows/comment_pr.yml
@@ -5,6 +5,11 @@ on:
     workflows: ["Receive PR"]
     types:
       - completed
+
+permissions:
+  actions: read
+  pull-requests: write
+
 jobs:
   comment_on_success:
     runs-on: ubuntu-latest
@@ -13,7 +18,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: "Download PR artifact"
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v7
         with:
           script: |
             var artifacts = await github.actions.listWorkflowRunArtifacts({
@@ -35,7 +40,7 @@ jobs:
       - name: Unzip artifact
         run: unzip pr.zip
       - name: Content has successfully PASSED validation
-        uses: actions/github-script@v3
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -55,7 +60,7 @@ jobs:
       github.event.workflow_run.conclusion == 'failure' }}
     steps:
       - name: "Download PR artifact"
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v7
         with:
           script: |
             var artifacts = await github.actions.listWorkflowRunArtifacts({
@@ -77,7 +82,7 @@ jobs:
       - name: Unzip artifact
         run: unzip pr.zip
       - name: Content has FAILED validation
-        uses: actions/github-script@v3
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/receive_pr.yml
+++ b/.github/workflows/receive_pr.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   validate_hugo_content:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves CodeQL alerts #1, #2, #3 (Medium: Workflow does not contain permissions).

- receive_pr.yml: contents:read (only checks out code and builds)
- comment_pr.yml: actions:read + pull-requests:write (downloads artifacts and posts PR comments)
- Bump actions/github-script from v3 to v7

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
