### PR TITLE
Fix Home link to use language-prefixed URL in multilingual site

### DIFF
--- a/src/hugo/themes/iot-atlas/layouts/partials/menu.html
+++ b/src/hugo/themes/iot-atlas/layouts/partials/menu.html
@@ -14,7 +14,7 @@
         <section id="homelinks">
           <ul>
             <li>
-                <a class="padding" href='{{ (cond (and (ne .Site.Params.landingPageURL nil) (hugo.IsMultilingual)) .Site.Params.landingPageURL "/") }}'>{{ safeHTML (cond (ne .Site.Params.landingPageName nil) .Site.Params.landingPageName "<i class='fas fa-home'></i> Home") }}</a>
+                <a class="padding" href='{{ (cond (and (ne .Site.Params.landingPageURL nil) (hugo.IsMultilingual)) .Site.Params.landingPageURL (.Site.Home.RelPermalink)) }}'>{{ safeHTML (cond (ne .Site.Params.landingPageName nil) .Site.Params.landingPageName "<i class='fas fa-home'></i> Home") }}</a>
             </li>
           </ul>
         </section>


### PR DESCRIPTION
Changed the Home button fallback from '/' to .Site.Home.RelPermalink so it navigates to the current language home (e.g. /en/, /es/) instead of the bare root URL which relies on a redirect that is not served correctly by the S3/CloudFront configuration.

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
