### PR TITLE
Remove oversized More/Tags shortcuts section from sidebar

### DIFF
--- a/src/hugo/config.toml
+++ b/src/hugo/config.toml
@@ -33,11 +33,6 @@ persona = "personae"
 [outputs]
 home = ["HTML", "RSS", "JSON"]
 
-[[menu.shortcuts]]
-name = "<i class='fas fa-tags'></i> Tags"
-url = "/tags/"
-weight = 30
-
 [languages]
 [languages.en]
 lang = "en"


### PR DESCRIPTION
The shortcuts menu only contained a Tags link with a disproportionately large 'More' heading that wasted sidebar space. Tags pages remain accessible via tag links in content.

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
