### PR TITLE
Fix language switcher using absolute URLs that bake in localhost

### DIFF
--- a/src/hugo/themes/iot-atlas/layouts/partials/menu.html
+++ b/src/hugo/themes/iot-atlas/layouts/partials/menu.html
@@ -61,9 +61,9 @@
               {{ $pageLang := .Page.Lang}}
               {{ range .Page.AllTranslations }}
                 {{ if eq .Lang $pageLang }}
-                  <option id="{{ .Lang }}" value="{{ .Permalink }}" selected>{{ .Language.Label }}</option>
+                  <option id="{{ .Lang }}" value="{{ .RelPermalink }}" selected>{{ .Language.Label }}</option>
                 {{ else }}
-                  <option id="{{ .Lang }}" value="{{ .Permalink }}">{{ .Language.Label }}</option>
+                  <option id="{{ .Lang }}" value="{{ .RelPermalink }}">{{ .Language.Label }}</option>
                 {{ end }}
               {{ end }}
             </select>


### PR DESCRIPTION
Changed .Permalink to .RelPermalink in the language selector options. .Permalink generates absolute URLs including the scheme and host, which gets set to http://localhost:1313 when hugo server runs during the validation step. Using .RelPermalink produces paths like /en/, /es/ that work regardless of the build environment.

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
